### PR TITLE
Improve test coverage

### DIFF
--- a/arteria/handlers/arteria_runfolder_handlers.py
+++ b/arteria/handlers/arteria_runfolder_handlers.py
@@ -76,26 +76,22 @@ async def get_next_runfolder(request):
     Finds unprocessed runfolder (state=ready) and then
     returns some information about this runfolder.
     """
-    try:
-        runfolders = list_runfolders(
-            Config()['monitored_directories'],
-            filter_key=lambda r: r.state == State.READY
+    runfolders = list_runfolders(
+        Config()['monitored_directories'],
+        filter_key=lambda r: r.state == State.READY
+    )
+
+    if len(runfolders) > 0:
+        runfolder_dict = serialize_runfolder_path(runfolders[0], request)
+
+        return web.json_response(
+            data=runfolder_dict,
+            status=200
         )
-
-        if len(runfolders) > 0:
-            runfolder_dict = serialize_runfolder_path(runfolders[0], request)
-
-            return web.json_response(
-                data=runfolder_dict,
-                status=200
-            )
-        else:
-            raise web.HTTPNoContent(
-                reason="No ready runfolder found."
-            )
-    except AssertionError as exc:
-        log.exception(exc)
-        raise web.HTTPNotFound(reason=exc) from exc
+    else:
+        raise web.HTTPNoContent(
+            reason="No ready runfolder found."
+        )
 
 
 @routes.get("/runfolders/pickup")
@@ -103,26 +99,22 @@ async def get_pickup_runfolder(request):
     """
     Used to start processing runfolders and also sets the runfolder to PENDING state.
     """
-    try:
-        runfolders = list_runfolders(
-            Config()['monitored_directories'],
-            filter_key=lambda r: r.state == State.READY
-        )
+    runfolders = list_runfolders(
+        Config()['monitored_directories'],
+        filter_key=lambda r: r.state == State.READY
+    )
 
-        if runfolders:
-            runfolders[0].state = State.PENDING
-            runfolder_dict = serialize_runfolder_path(runfolders[0], request)
-            return web.json_response(
-                data=runfolder_dict,
-                status=200
-            )
-        else:
-            raise web.HTTPNoContent(
-                reason="No ready runfolders available."
-            )
-    except AssertionError as exc:
-        log.exception(exc)
-        raise web.HTTPNotFound(reason=exc) from exc
+    if runfolders:
+        runfolders[0].state = State.PENDING
+        runfolder_dict = serialize_runfolder_path(runfolders[0], request)
+        return web.json_response(
+            data=runfolder_dict,
+            status=200
+        )
+    else:
+        raise web.HTTPNoContent(
+            reason="No ready runfolders available."
+        )
 
 
 @routes.get("/runfolders")
@@ -132,24 +124,20 @@ async def get_all_runfolders(request):
     match the state specified (or all runfolders when state
     is not specified)
     """
-    try:
-        runfolders = list_runfolders(
-            Config()['monitored_directories'],
-            filter_key=lambda r: r.state == State.READY
-        )
+    runfolders = list_runfolders(
+        Config()['monitored_directories'],
+        filter_key=lambda r: r.state == State.READY
+    )
 
-        runfolders = [
-            serialize_runfolder_path(runfolder, request)
-            for runfolder in runfolders
-        ]
+    runfolders = [
+        serialize_runfolder_path(runfolder, request)
+        for runfolder in runfolders
+    ]
 
-        return web.json_response(
-            data={"runfolders": runfolders},
-            status=200
-        )
-    except AssertionError as exc:
-        log.exception(exc)
-        raise web.HTTPNotFound(reason=exc) from exc
+    return web.json_response(
+        data={"runfolders": runfolders},
+        status=200
+    )
 
 
 def get_host_link(request, runfolder_path, ):

--- a/arteria/models/runfolder_utils.py
+++ b/arteria/models/runfolder_utils.py
@@ -107,9 +107,6 @@ class Runfolder():
             metadata: a dict containing up to two keys: "reagent_kit_barcode"
             and "library_tube_barcode"
         """
-        if not self.run_parameters:
-            log.warning(f"No metadata found for runfolder {self.path}")
-
         metadata = {}
 
         try:
@@ -131,6 +128,9 @@ class Runfolder():
                     )
             except (KeyError, StopIteration):
                 log.debug("Library tube barcode not found")
+
+        if not metadata:
+            log.warning(f"No metadata found for runfolder {self.path}")
 
         return metadata
 

--- a/arteria/models/runfolder_utils.py
+++ b/arteria/models/runfolder_utils.py
@@ -208,10 +208,10 @@ class Instrument:
         if instrument_id is None:
             try:
                 instrument_id = next(
-                    self.run_parameters.get(key)
+                    self.run_parameters[key]
                     for key in self.RUNPARAMETERS_INSTRUMENT_ID_KEYS
-                    if key in self.run_parameters.keys()
+                    if key in self.run_parameters
                 )
             except StopIteration as e:
-                raise TypeError(f"{self.instrument} is not recognized") from e
+                raise TypeError("Instrument not recognized") from e
         return instrument_id

--- a/arteria/models/runfolder_utils.py
+++ b/arteria/models/runfolder_utils.py
@@ -27,14 +27,8 @@ def list_runfolders(monitored_directories, filter_key=lambda r: True):
         try:
             if filter_key(runfolder := Runfolder(monitored_runfolders_path)):
                 runfolders.append(runfolder)
-        except AssertionError as e:
-            if (
-                str(e) != (
-                    "File [Rr]unParameters.xml not found in runfolder "
-                    f"{monitored_runfolders_path}"
-                )
-            ):
-                raise
+        except AssertionError:
+            log.exception(f"Ignoring {monitored_runfolders_path}")
 
     return runfolders
 

--- a/tests/cli/test_arteria_runfolder_cli.py
+++ b/tests/cli/test_arteria_runfolder_cli.py
@@ -1,0 +1,20 @@
+import tempfile
+from unittest.mock import patch
+import yaml
+
+from arteria.services.arteria_runfolder import main
+
+
+@patch("arteria.services.arteria_runfolder.get_app")
+@patch("aiohttp.web.run_app")
+def test_cli_parameters(mock_run_app, mock_get_app):
+    config = {"item": 1}
+    with tempfile.NamedTemporaryFile(mode='w') as config_file:
+        yaml.dump(config, config_file)
+        with patch(
+            "sys.argv",
+            ["", "--config_file", config_file.name]
+        ):
+            main()
+
+            mock_get_app.assert_called_with(config)

--- a/tests/resources/RunParameters_corrupt.xml
+++ b/tests/resources/RunParameters_corrupt.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunParameters xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <InstrumentSerialNumber>LH00179</InstrumentSerialNumber>
+</RunParameters>

--- a/tests/unit/test_runfolder_utils.py
+++ b/tests/unit/test_runfolder_utils.py
@@ -152,3 +152,9 @@ def test_get_marker_file(runparameter_file, marker_file):
     )["RunParameters"]
     instrument = Instrument(run_parameters)
     assert instrument.completed_marker_file == marker_file
+
+
+def test_get_marker_unknown_instrument():
+    fake_run_parameters = {"fake_id": "12345"}
+    with pytest.raises(TypeError):
+        _ = Instrument(fake_run_parameters).completed_marker_file

--- a/tests/unit/test_runfolder_utils.py
+++ b/tests/unit/test_runfolder_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -123,11 +124,17 @@ class TestRunfolder():
             ("RunParameters_MiSeq.xml", {"reagent_kit_barcode": "MS6728155-600V3"}),
             ("RunParameters_NS6000.xml", {"library_tube_barcode": "NV0217945-LIB"}),
             ("RunParameters_NSXp.xml", {"library_tube_barcode": "LC1025031-LC1"}),
+            ("RunParameters_corrupt.xml", {}),
         ],
         indirect=["runfolder"],
     )
-    def test_get_metadata(self, runfolder, metadata):
+    def test_get_metadata(self, runfolder, metadata, caplog):
         assert runfolder.metadata == metadata
+        if not metadata:
+            assert re.search(
+                r"WARNING .*:\d+ No metadata found for runfolder (\/\w+)+",
+                caplog.text
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_runfolder_utils.py
+++ b/tests/unit/test_runfolder_utils.py
@@ -1,4 +1,3 @@
-import os
 import re
 import shutil
 import tempfile
@@ -15,10 +14,11 @@ from arteria.models.runfolder_utils import list_runfolders, Runfolder, Instrumen
 @pytest.fixture()
 def monitored_directory():
     with tempfile.TemporaryDirectory() as monitored_dir:
-        for i in range(3):
+        for i in range(4):
             runfolder_path = Path(monitored_dir) / f"runfolder{i}"
             runfolder_path.mkdir()
-            (runfolder_path / "CopyComplete.txt").touch()
+            if i < 3:
+                (runfolder_path / "CopyComplete.txt").touch()
 
             if i == 0:
                 (runfolder_path / ".arteria").mkdir()
@@ -61,7 +61,7 @@ def runfolder(request):
 
 
 def test_list_runfolders(monitored_directory):
-    assert len(os.listdir(monitored_directory)) == 4
+    assert len(list(Path(monitored_directory).iterdir())) == 5
 
     runfolders = list_runfolders([monitored_directory])
 


### PR DESCRIPTION
This PR improves the overall test coverage. While working on this, I've fixed the following issues:
- `/runfolders`, `/runfolder/next` and `/runfolder/pickup` never have to return `404 Not Found`. If there is no runfolder to return, they should simply return an empty list or `204 No Content`.
- Since we are checking for run_parameters when initializing a `Runfolder`, we can assume this attribute exists in all the other methods.
- The "no metadata" warning message should be logged when none of the metadata fields is found.
- Add tests for the cli parameters.