### PR TITLE
Converting state gotten from request to uppercase

### DIFF
--- a/arteria/handlers/arteria_runfolder_handlers.py
+++ b/arteria/handlers/arteria_runfolder_handlers.py
@@ -35,9 +35,9 @@ async def post_runfolders(request):
         log.exception(exc)
         raise web.HTTPNotFound(reason=exc) from exc
 
-    state = (data["state"]).upper()
+    state = (data["state"])
     try:
-        runfolder.state = State[state]
+        runfolder.state = State.get_state(state)
     except KeyError as exc:
         raise web.HTTPBadRequest(reason=f"The state '{state}' is not valid") from exc
 

--- a/arteria/handlers/arteria_runfolder_handlers.py
+++ b/arteria/handlers/arteria_runfolder_handlers.py
@@ -15,8 +15,8 @@ log = logging.getLogger(__name__)
 @routes.post("/api/1.0/runfolders/path{runfolder:/.*}")
 async def post_runfolders(request):
     """
-    When this is called with payload {"state": "STARTED"},
-    the state of the runfolder is set to STARTED
+    When this is called with payload {"state": "started"},
+    the state of the runfolder is set to started
     """
 
     data = await request.json()

--- a/arteria/handlers/arteria_runfolder_handlers.py
+++ b/arteria/handlers/arteria_runfolder_handlers.py
@@ -35,7 +35,7 @@ async def post_runfolders(request):
         log.exception(exc)
         raise web.HTTPNotFound(reason=exc) from exc
 
-    state = data["state"]
+    state = (data["state"]).upper()
     try:
         runfolder.state = State[state]
     except KeyError as exc:

--- a/arteria/models/state.py
+++ b/arteria/models/state.py
@@ -9,3 +9,6 @@ class State(Enum):
     DONE = "done"
     ERROR = "error"
     CANCELLED = "cancelled"
+
+    def get_state(state):
+        return State[state.upper()]

--- a/tests/integration/test_arteria_runfolder.py
+++ b/tests/integration/test_arteria_runfolder.py
@@ -110,21 +110,23 @@ async def test_post_runfolders_path(client, config, runfolder):
     url = f"/api/1.0/runfolders/path{runfolder['path']}"
     # url should not have two '/' after combining the static and dynamic parts
     assert not re.search(r'runfolders/path//', url)
+    states = ["started", "STARTED"]
 
-    async with client.request(
-        "POST", url, json={"state": "started"}
-    ) as resp:
-        assert resp.status == 200
+    for state in states:
+        async with client.request(
+            "POST", url, json={"state": state}
+        ) as resp:
+            assert resp.status == 200
 
-        state = runfolder.get('path') / ".arteria/state"
-        assert state.read_text() == State.STARTED.value
+            state = runfolder.get('path') / ".arteria/state"
+            assert state.read_text() == State.STARTED.value
 
-        state_control = (
-            Path(config["monitored_directories"][0])
-            / runfolder['path'].name
-            / ".arteria/state"
-        )
-        assert state_control.read_text() == State.DONE.value
+            state_control = (
+                Path(config["monitored_directories"][0])
+                / runfolder['path'].name
+                / ".arteria/state"
+            )
+            assert state_control.read_text() == State.DONE.value
 
 
 @pytest.mark.parametrize("runfolder", [{"state": State.READY.name}], indirect=True)

--- a/tests/integration/test_arteria_runfolder.py
+++ b/tests/integration/test_arteria_runfolder.py
@@ -148,7 +148,7 @@ async def test_post_runfolders_path_missing_runfolder(client, config, runfolder)
                     "200624_A00834_0183_FAKE_RUNFOLDER"
                 }'
             ),
-            json={"state": "STARTED"}
+            json={"state": "started"}
     ) as resp:
 
         assert resp.status == 404
@@ -160,7 +160,7 @@ async def test_post_runfolder_unmonitored_dir(client, config, runfolder):
     runfolder_name = runfolder["path"].name
     async with client.request(
         "POST", f"/api/1.0/runfolders/path/tmp/unmonitored_path/{runfolder_name}",
-        json={"state": "STARTED"},
+        json={"state": "started"},
     ) as resp:
         assert resp.status == 400
 

--- a/tests/integration/test_arteria_runfolder.py
+++ b/tests/integration/test_arteria_runfolder.py
@@ -112,7 +112,7 @@ async def test_post_runfolders_path(client, config, runfolder):
     assert not re.search(r'runfolders/path//', url)
 
     async with client.request(
-        "POST", url, json={"state": "STARTED"}
+        "POST", url, json={"state": "started"}
     ) as resp:
         assert resp.status == 200
 


### PR DESCRIPTION
This solves the error  `body: '400: The state ''started'' is not valid'` found while validating biopickup