### PR TITLE
Corrected runfolder path returned by API

### DIFF
--- a/arteria/handlers/arteria_runfolder_handlers.py
+++ b/arteria/handlers/arteria_runfolder_handlers.py
@@ -155,7 +155,7 @@ def serialize_runfolder_path(runfolder_cls, request):
     runfolder_dict = runfolder_cls.to_dict()
     runfolder_dict['service_version'] = __version__
     runfolder_path = Path(runfolder_dict['path'])
-    runfolder_dict['path'] = str(runfolder_path)
+    runfolder_dict['path'] = runfolder_path.as_posix()
     runfolder_dict['host'], runfolder_dict['link'] = get_host_link(request, runfolder_path)
 
     return runfolder_dict

--- a/arteria/handlers/arteria_runfolder_handlers.py
+++ b/arteria/handlers/arteria_runfolder_handlers.py
@@ -155,7 +155,7 @@ def serialize_runfolder_path(runfolder_cls, request):
     runfolder_dict = runfolder_cls.to_dict()
     runfolder_dict['service_version'] = __version__
     runfolder_path = Path(runfolder_dict['path'])
-    runfolder_dict['path'] = runfolder_path.as_uri()
+    runfolder_dict['path'] = str(runfolder_path)
     runfolder_dict['host'], runfolder_dict['link'] = get_host_link(request, runfolder_path)
 
     return runfolder_dict

--- a/tests/integration/test_arteria_runfolder.py
+++ b/tests/integration/test_arteria_runfolder.py
@@ -89,7 +89,7 @@ def get_expected_runfolder(runfolder, resp, state=None):
             f"/api/1.0/runfolders/path{runfolder["path"]}"
         )
     runfolder['state'] = state if state else runfolder['state']
-    runfolder['path'] = str(runfolder['path'])
+    runfolder['path'] = runfolder['path'].as_posix()
 
     return runfolder
 

--- a/tests/integration/test_arteria_runfolder.py
+++ b/tests/integration/test_arteria_runfolder.py
@@ -89,7 +89,7 @@ def get_expected_runfolder(runfolder, resp, state=None):
             f"/api/1.0/runfolders/path{runfolder["path"]}"
         )
     runfolder['state'] = state if state else runfolder['state']
-    runfolder['path'] = runfolder['path'].as_uri()
+    runfolder['path'] = str(runfolder['path'])
 
     return runfolder
 


### PR DESCRIPTION
There was an issue with snpseq_packs sensor as the runfolder path was been passed as `file:///data/biopickup/incoming/runfolders/200624_A00834_0183_BHMTFYTINY` instead of `/data/biopickup/incoming/runfolders/200624_A00834_0183_BHMTFYTINY.`

The below code fixes this. 